### PR TITLE
Pass project config from `.debugger.cson` to debugger implementation.

### DIFF
--- a/lib/debugger-controller.js
+++ b/lib/debugger-controller.js
@@ -87,7 +87,7 @@ export default class DebuggerController {
       return
     }
 
-    proxy.startSession(target, debug)
+    proxy.startSession(target, debug, config.data)
   }
 
   stop(): void {

--- a/lib/debugger-proxy.js
+++ b/lib/debugger-proxy.js
@@ -32,7 +32,7 @@ export default class DebuggerProxy {
     return this.activeDebugger
   }
 
-  startSession(target: DebuggerTarget, debug: Debugger): void {
+  startSession(target: DebuggerTarget, debug: Debugger, config: Object): void {
 
     this.activeSubscriptions.add(debug.onBreakpointEvent(event => {
 
@@ -78,7 +78,7 @@ export default class DebuggerProxy {
       this.emitter.emit('target', event)
     }))
 
-    debug.start(target, this.breakpoints)
+    debug.start(target, this.breakpoints, config)
     this.activeDebugger = debug
   }
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -30,7 +30,7 @@ export type Debugger = {
 
   onTargetEvent(callback: Function): void,
 
-  start(target: DebuggerTarget): void,
+  start(target: DebuggerTarget, config: Object): void,
 
   stop(): void,
 


### PR DESCRIPTION
This is useful at least for GDB, as different projects are likely
to use different GDB binaries (for different target architectures).
This should be project specific configuration rather than package
configuration.